### PR TITLE
Be bug invites contacts 52

### DIFF
--- a/client/src/components/AuthenticatedApp/AuthenticatedApp.js
+++ b/client/src/components/AuthenticatedApp/AuthenticatedApp.js
@@ -39,7 +39,12 @@ const AuthenticatedApp = () => {
                     </Grid>
 
                     <Grid item xs={8}>
-                        {/* <Chat messages={messages} user={user} selectedContact={selectedContact} /> */}
+                    <Router>
+                      <Switch>
+                        <Route exact path="/" component={Chat} />
+                        <Route exact path="/conversations" component={Chat} />
+                      </Switch>
+                    </Router>
                     </Grid>
                 </Grid>
             </MuiThemeProvider>
@@ -65,3 +70,4 @@ shared state, user and/or contacts
       </Router>
     </MuiThemeProvider>
 */
+//                        {/* <Chat messages={messages} user={user} selectedContact={selectedContact} /> */}

--- a/client/src/components/Chat/Chat.js
+++ b/client/src/components/Chat/Chat.js
@@ -7,7 +7,7 @@ import MessageDisplay from './MessageDisplay';
 import MessageInput from './MessageInput';
 
 const Chat = props => {
-  const {user, messages, selectedContact} = props;
+  //const {user, messages, selectedContact} = props;
   return (
     <Grid
      item
@@ -15,7 +15,8 @@ const Chat = props => {
      sm={9}
      direction='row'
     >
-      <ChatHeader 
+      <h1>placeholder chat</h1>
+      {/* <ChatHeader 
         selectedContact={selectedContact}
       />
       <MessageDisplay
@@ -25,7 +26,7 @@ const Chat = props => {
       <MessageInput
         username={user.username}
         sendMessage={props.sendMessage}
-      />
+      /> */}
     </Grid>  
   );
 }

--- a/server/routes/invitation.js
+++ b/server/routes/invitation.js
@@ -173,22 +173,28 @@ router.get("/user/:id",
 
 // Returns contacts that the current user accepted invitations from
 router.get("/user/:to_email/contacts",
-    //passport.authenticate('jwt', { session: false }),
-    function(req, res, next) {
-        const {to_email} = req.params;
+  //passport.authenticate('jwt', { session: false }),
+  function(req, res, next) {
+    const {to_email} = req.params;
 
-        Invitation.find({"to_user_email": to_email, "approved": true },
-          function(err, invitations) {
-            if (err) return console.error('Contacts could not be retrieved.', err);
-            if (invitations && invitations.length) {
-              let contacts = invitations.map(invite => invite.from_user_email);
-              res.status(201).json({type: 'success', contacts});
-            } else {
-              res.status(201).json({type: 'success', message: 'No contacts were found.', contacts: []})
-            }
-          }
-        )
-    }
+    Invitation.find({
+      $or: [
+        {"to_user_email": to_email, "approved": true },
+        {"from_user_email": to_email, "approved": true },
+      ]
+    }, function(err, invitations) {
+      if (err) return console.error('Contacts could not be retrieved.', err);
+      if (invitations && invitations.length) {
+        console.log('invitations', invitations)
+        let contacts = invitations.map(invite => {
+          return invite.to_user_email === to_email ? invite.from_user_email: invite.to_user_email;
+        });
+        res.status(201).json({type: 'success', contacts});
+      } else {
+        res.status(201).json({type: 'success', message: 'No contacts were found.', contacts: []})
+      }
+    });
+  }
 );
 
 module.exports = router;

--- a/server/routes/invitation.js
+++ b/server/routes/invitation.js
@@ -122,7 +122,8 @@ router.post("/user/:fromEmail",
                                   res.json({ type: "success", message: `${inviteCreatedInternalMessage}`});
                                 })
                               } else {
-                                res.status(200).json({ type: "error", message: 'The invitations requested to create were duplicates, pending, or rejected.'})
+                                inviteNotCreatedEmailMessage = `Invitations were not sent to ${dupeInviteRecipients.join(', ')} because the invitation was already sent, pending, or rejected.`;
+                                res.status(200).json({ type: "error", message: inviteNotCreatedEmailMessage})
                               }
                             }
                           })

--- a/server/routes/invitation.js
+++ b/server/routes/invitation.js
@@ -48,11 +48,6 @@ router.post("/user/:fromEmail",
                       //1 handle case where recipients include registered users and non registered
                         if (curUserEmails.length && nonCurUserEmails.length) {
 //TODO add query to verify requested email does not exist
-                          Invitation.find({from_user_email: fromEmail}, 'to_user_email', function(err, invitations) {
-                            if (err) console.error('Could not find invitations during duplicate invites check', err);
-                            if (invitations) console.log('duplicate invitations', invitations)
-                          })
-
 
 
 
@@ -91,12 +86,12 @@ router.post("/user/:fromEmail",
                               if (nonDupeInviteRecipients.length) {
                                 let newInvites = nonDupeInviteRecipients.map(to_user_email => {return {to_user_email, from_user_email: fromEmail}});
                                 Invitation.insertMany(newInvites, function(err) {
-                                    if (err) return console.error(err);
-                                    inviteCreatedInternalMessage =  `Internal invitations were sent to ${nonDupeInviteRecipients.join(', ')}.`
-                                    if (!nonCurUserEmails.length) {
-                                        res.json({ type: "success", message: `${inviteCreatedInternalMessage}`});
-                                    }
+                                  if (err) return console.error(err);
+                                  inviteCreatedInternalMessage =  `Internal invitations were sent to ${nonDupeInviteRecipients.join(', ')}.`
+                                  res.json({ type: "success", message: `${inviteCreatedInternalMessage}`});
                                 })
+                              } else {
+                                res.status(200).json({ type: "error", message: 'The invitations requested to create were duplicates, pending, or rejected.'})
                               }
                             }
                           })

--- a/server/routes/invitation.js
+++ b/server/routes/invitation.js
@@ -24,7 +24,7 @@ router.post("/user/:fromEmail",
         let inviteNotCreatedEmailMessage = '';
 
         if (toEmailAr.length === 0) {
-            return res.status(400).json({error: 'No email addresses for invitation recipients were provided.'})
+          return res.status(400).json({error: 'No email addresses for invitation recipients were provided.'})
         }
         toEmailAr.forEach(email => {
             if (validator.isEmail(email)) {
@@ -32,7 +32,7 @@ router.post("/user/:fromEmail",
             } else {
                 invalidEmails.push(email);
             }
-        })
+        });
         if (!validEmails.length) {
             return res.status(400).json({error: 'Email addresses for invitation recipients were invalid. Please check the spelling.'})
         } else {
@@ -51,6 +51,7 @@ router.post("/user/:fromEmail",
                           //verify requested invite does not exist
                           Invitation.find({from_user_email: fromEmail}, 'to_user_email', function(err, invitations) {
                             if (err) console.error('Could not find invitations during duplicate invites check', err);
+                            //line 54 missing closing brace
                             if (invitations && invitations.length) {
                               invitations.forEach(invite => {
                                 if (dupeInviteRecipients.indexOf(invite.to_user_email) === -1) {
@@ -75,7 +76,7 @@ router.post("/user/:fromEmail",
                                         }
                                       })
                                       .catch(err => {
-                                          console.error('sendgrid email err', err)
+                                          console.error('sendgrid email err', err);
                                       })
                                   }
                                 })
@@ -98,7 +99,8 @@ router.post("/user/:fromEmail",
                                     })
                                 }
                               }
-                            
+                            }
+                          })
                         } else if (curUserEmails.length) {
 //TODO verify that requested email does not exist
                           Invitation.find({from_user_email: fromEmail}, 'to_user_email', function(err, invitations) {
@@ -111,7 +113,8 @@ router.post("/user/:fromEmail",
                               });
                               nonDupeInviteRecipients = curUserEmails.filter(email =>   dupeInviteRecipients.indexOf(email) === -1);
                               if (nonDupeInviteRecipients.length) {
-                                let newInvites = nonDupeInviteRecipients.map(to_user_email => {return {to_user_email, from_user_email: fromEmail}});
+                                let newInvites = nonDupeInviteRecipients.map(to_user_email => {
+                                  return {to_user_email, from_user_email: fromEmail}});
                                 Invitation.insertMany(newInvites, function(err) {
                                   if (err) return console.error(err);
                                   inviteCreatedInternalMessage =  `Internal invitations were sent to ${nonDupeInviteRecipients.join(', ')}.`

--- a/server/routes/invitation.js
+++ b/server/routes/invitation.js
@@ -125,6 +125,14 @@ router.post("/user/:fromEmail",
                                 inviteNotCreatedEmailMessage = `Invitations were not sent to ${dupeInviteRecipients.join(', ')} because the invitation was already sent, pending, or rejected.`;
                                 res.status(200).json({ type: "error", message: inviteNotCreatedEmailMessage})
                               }
+                            } else if (invitations.length === 0) {
+                              let newInvites = curUserEmails.map(to_user_email => {
+                                return {to_user_email, from_user_email: fromEmail}});
+                              Invitation.insertMany(newInvites, function(err) {
+                                if (err) return console.error(err);
+                                inviteCreatedInternalMessage =  `Internal invitations were sent to ${curUserEmails.join(', ')}.`
+                                res.json({ type: "success", message: `${inviteCreatedInternalMessage}`});
+                              })
                             }
                           })
                         } else if (nonCurUserEmails.length) {
@@ -185,7 +193,6 @@ router.get("/user/:to_email/contacts",
     }, function(err, invitations) {
       if (err) return console.error('Contacts could not be retrieved.', err);
       if (invitations && invitations.length) {
-        console.log('invitations', invitations)
         let contacts = invitations.map(invite => {
           return invite.to_user_email === to_email ? invite.from_user_email: invite.to_user_email;
         });

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -80,7 +80,7 @@ router.post('/login', (req, res) => {
 });
 
 router.get("/:fromEmail/referralId",
-  //passport.authenticate('jwt', { session: false }),
+  passport.authenticate('jwt', { session: false }),
   function(req, res, next) {
     const {fromEmail} = req.params
     User.findOne({email: fromEmail}, function(err, user) {


### PR DESCRIPTION
* I'm not crazy about the additional nested logic for creating invites (no dupes) but am not sure how best to clean it up.
* get contacts should now also include invites sent from the logged in user and approved.
* also included: invitation dialog is getting the logged in user email from auth state (making get referral id api request with the jwt token)
* for authenticated app, a couple of default routes have been added (to help test redirecting from /login to / route).

===
not sure about this syntax when client makes the api request, should it be

```
headers: {
        'Authorization': `${jwtToken}` 
      },
```

OR

```
headers: {
        'Authorization': `Bearer ${jwtToken}`
      },
```