### PR TITLE
Invite duplicate 76b

### DIFF
--- a/client/src/components/Sidebar/SidebarHeader.js
+++ b/client/src/components/Sidebar/SidebarHeader.js
@@ -80,7 +80,6 @@ const SidebarHeader = (props) => {
       <div className="headerLeft">
         <Avatar className={classes.purple}>{initial}</Avatar>
         <Typography variant='h5' className={classes.chatHeaderName}>{email.split('@')[0]}</Typography>
-        <Typography variant='p2'>online status todo</Typography>
       </div>
       <div className="headerSpacer" />
       <div className="headerRight">

--- a/server/util/index.js
+++ b/server/util/index.js
@@ -1,0 +1,20 @@
+const getEmailSendSuccessMessage = (emails) => {
+  return `Email invitations were sent to ${emails.join(', ')}`;
+}
+
+const getEmailSendMixedMessage = (sentEmails, unsentEmails) => {
+  let inviteNotCreatedEmailMessage = `Invitations were not sent to ${unsentEmails.join(', ')} because the invitation was already sent, pending, or rejected.`;
+  let inviteCreatedEmailMessage = `Invitations were sent to ${sentEmails.join(', ')}.`;
+  return `${inviteCreatedEmailMessage} ${inviteNotCreatedEmailMessage}`;
+}
+
+//internal invitations to registered users
+const getInviteSendSuccessMessage = (emails) => {
+  return `Invitations were sent to ${emails.join(', ')}.`
+}
+
+const getInviteNotSentMessage = (emails) => {
+  return `Invitations were not sent to ${emails.join(', ')} because the invitation was already sent, pending, or rejected.`;
+}
+
+module.exports = {getEmailSendSuccessMessage, getEmailSendMixedMessage, getInviteSendSuccessMessage, getInviteNotSentMessage};


### PR DESCRIPTION
the definition of a duplicate invite is a bit conservative but it will definitely prevent the occurrence of multiple conversations existing between the same two users

a duplicate invite is detected if:
* there is an approved invitation between the two users (both directions)
* there is a pending invitation between the two users  (both directions)
* there is a rejected invitation between the two users  (both directions)

a small attempt at refactoring the POST invitation route was made but just at the level of abstracting the response message formation. this felt like the least destructive change before the demo (least likely to cause a new bug).