### PR TITLE
[BUG]: fixed messages not loading after clicking on contact via search

### DIFF
--- a/client/src/components/Sidebar/Contacts/Friends.js
+++ b/client/src/components/Sidebar/Contacts/Friends.js
@@ -64,7 +64,7 @@ const Friends = props => {
       container
       spacing={2}
       key={curr}
-      onClick={(ev) => contactClickHandler(curr)}
+      onClick={() => contactClickHandler(curr)}
       className={classes.contactListItem}
     >
       <Grid item>

--- a/client/src/components/Sidebar/Sidebar.js
+++ b/client/src/components/Sidebar/Sidebar.js
@@ -84,7 +84,7 @@ const Sidebar = props => {
     if(email){
       const res = await axios.get(`http://localhost:3001/invitations/user/${email}/contacts?q=${q}`, {headers: { Authorization: authToken}});
       if(res.data.contacts.length !== 0){
-      setFriends(res.data.contacts);
+        setFriends(res.data.contacts);
       }
       else {
         setFriends(['You dont have any contacts. Send invites to initiate a conversation']);

--- a/server/routes/invitation.js
+++ b/server/routes/invitation.js
@@ -257,8 +257,7 @@ router.get("/user/:to_email/contacts",
         });
         //if search query provided
         if(req.query.q){
-          contacts = contacts.filter(contact => contact.includes(req.query.q))
-                             .map(filteredContact => filteredContact.split('@')[0]);                             
+          contacts = contacts.filter(contact => contact.includes(req.query.q));                             
         }
         res.status(201).json({type: 'success', contacts});
       } else {


### PR DESCRIPTION
- After contacts search, when a contact was clicked, its conversations would not load. They would load otherwise without doing a search.
- Split email on server side was causing the issue since the email would not be found on subsequent call